### PR TITLE
allow multiple config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ WantedBy=multi-user.target
 The following configuration options are available and must be set via Environment variable:
 - BORGMATIC_EXPORTER_PORT - Set the http listen port. Default to `8090`
 - BORGMATIC_EXPORTER_ENDPOINT - Set the metrics endpoint. Defaults to `metrics`
-- BORGMATIC_EXPORTER_CONFIG - Overrides the default config path using `borgmatic -c` Defaults to the Borgmatic defaults
+- BORGMATIC_EXPORTER_CONFIG - Overrides the default config paths using `borgmatic -c`. Uses Borgmatic defaults if not set. Multiple config paths must be separated with spaces, i.e `/path/to/config1.yaml /path/to/config2.yaml`

--- a/internal/borgmatic/archives.go
+++ b/internal/borgmatic/archives.go
@@ -4,12 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"os/exec"
+	"strings"
 )
 
 func getArchives(config string) ([]ListResult, error) {
 	var borgmaticCmd = exec.Command("borgmatic")
 	if config != "" {
-		borgmaticCmd.Args = append(borgmaticCmd.Args, "-c", config)
+		borgmaticCmd.Args = append(borgmaticCmd.Args, "-c")
+		configs := strings.Split(config, " ")
+		borgmaticCmd.Args = append(borgmaticCmd.Args, configs...)
+
 	}
 	borgmaticCmd.Args = append(borgmaticCmd.Args, "list", "--json")
 

--- a/internal/borgmatic/info.go
+++ b/internal/borgmatic/info.go
@@ -4,12 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"os/exec"
+	"strings"
 )
 
 func getInfo(config string) ([]InfoResult, error) {
 	var borgmaticCmd = exec.Command("borgmatic")
 	if config != "" {
-		borgmaticCmd.Args = append(borgmaticCmd.Args, "-c", config)
+		borgmaticCmd.Args = append(borgmaticCmd.Args, "-c")
+		configs := strings.Split(config, " ")
+		borgmaticCmd.Args = append(borgmaticCmd.Args, configs...)
+
 	}
 	borgmaticCmd.Args = append(borgmaticCmd.Args, "info", "--json")
 


### PR DESCRIPTION
Allow multiple config paths by providing multiple config paths separated by spaces via BORGMATIC_EXPORTER_CONFIG. I.e - `BORGMATIC_EXPORTER_CONFIG="/path/to/config1.yaml /path/to/config2.yaml" borgmatic-exporter`