### PR TITLE
build: switch to golang alpine image for docker build stage

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS build-stage
+FROM golang:1.21-alpine AS build-stage
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
Address issue #52 by switching Docker build-stage Golang image from Debian to Alpine