### PR TITLE
chore: make listen address fully configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A multi-architecture docker image with usage instructions is available at https:
 
 ## Configuration options
 The following configuration options are available and must be set via Environment variable:
+- BORGMATIC_EXPORTER_HOST - Set the http listen address. Default to `localhost`
 - BORGMATIC_EXPORTER_PORT - Set the http listen port. Default to `8090`
 - BORGMATIC_EXPORTER_ENDPOINT - Set the metrics endpoint. Defaults to `metrics`
 - BORGMATIC_EXPORTER_CONFIG - Overrides the default config paths using `borgmatic -c`. Uses Borgmatic defaults if not set. Multiple config paths must be separated with spaces, i.e `/path/to/config1.yaml /path/to/config2.yaml`

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A multi-architecture docker image with usage instructions is available at https:
 
 ## Configuration options
 The following configuration options are available and must be set via Environment variable:
-- BORGMATIC_EXPORTER_HOST - Set the http listen address. Default to `localhost`
+- BORGMATIC_EXPORTER_HOST - Set the http listen address. Default to `0.0.0.0`
 - BORGMATIC_EXPORTER_PORT - Set the http listen port. Default to `8090`
 - BORGMATIC_EXPORTER_ENDPOINT - Set the metrics endpoint. Defaults to `metrics`
 - BORGMATIC_EXPORTER_CONFIG - Overrides the default config paths using `borgmatic -c`. Uses Borgmatic defaults if not set. Multiple config paths must be separated with spaces, i.e `/path/to/config1.yaml /path/to/config2.yaml`

--- a/cmd/borgmatic-exporter/main.go
+++ b/cmd/borgmatic-exporter/main.go
@@ -27,8 +27,9 @@ func main() {
 	prometheus.MustRegister(collector)
 
 	http.Handle(fmt.Sprintf("/%s", config.Endpoint), promhttp.Handler())
-	logs.Logger.Info(fmt.Sprintf("listening on http://localhost:%s/%s", config.Port, config.Endpoint))
-	err = http.ListenAndServe(fmt.Sprintf(":%s", config.Port), nil)
+	addr := config.Host + ":" + config.Port
+	logs.Logger.Info(fmt.Sprintf("listening on http://%s/%s", addr, config.Endpoint))
+	err = http.ListenAndServe(addr, nil)
 
 	if errors.Is(err, http.ErrServerClosed) {
 		logs.Logger.Error("server closed",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 type specification struct {
-	Host      string `default:"localhost"`
+	Host      string `default:"0.0.0.0"`
 	Port      string `default:"8090"`
 	Endpoint  string `default:"metrics"`
 	Config    string `default:""`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 )
 
 type specification struct {
+	Host      string `default:"localhost"`
 	Port      string `default:"8090"`
 	Endpoint  string `default:"metrics"`
 	Config    string `default:""`


### PR DESCRIPTION
Adds the host option, to make the full listening address configurable.

This also fixes an inaccuracy in the log message "listening on http://localhost:...".
The message didn't properly reflect the listening host.
Notably, the previous value of ":<port>" is an alias for "0.0.0.0:<port>" and not "localhost:<port>".

I'm not too sure if the default for `BORGMATIC_EXPORTER_HOST` should be `0.0.0.0` to stay backwards compatible with configurations based on the old code.